### PR TITLE
Add gitignore entries for build outputs and env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
-node_modules/*
+node_modules/
+dist/
+.env
+.mastra/
+*.log


### PR DESCRIPTION
## Summary
- avoid committing build outputs and environment files

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'aws-lambda', 'bunyan', etc.)*